### PR TITLE
⚡ Optimize distance check in nested node loops

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,50 @@
+const nodes = [];
+for (let i = 0; i < 500; i++) {
+    nodes.push({ x: Math.random() * 800, y: Math.random() * 600 });
+}
+
+function runBaseline() {
+    let lines = 0;
+    const start = performance.now();
+    for (let k = 0; k < 1000; k++) {
+        for (let i = 0; i < nodes.length; i++) {
+            for (let j = i + 1; j < nodes.length; j++) {
+                const dx = nodes[i].x - nodes[j].x,
+                      dy = nodes[i].y - nodes[j].y;
+                const d = Math.sqrt(dx * dx + dy * dy);
+                if (d < 130) {
+                    lines++;
+                }
+            }
+        }
+    }
+    const end = performance.now();
+    return end - start;
+}
+
+function runOptimized() {
+    let lines = 0;
+    const start = performance.now();
+    for (let k = 0; k < 1000; k++) {
+        for (let i = 0; i < nodes.length; i++) {
+            for (let j = i + 1; j < nodes.length; j++) {
+                const dx = nodes[i].x - nodes[j].x,
+                      dy = nodes[i].y - nodes[j].y;
+                const dSq = dx * dx + dy * dy;
+                if (dSq < 16900) { // 130 * 130
+                    const d = Math.sqrt(dSq);
+                    lines++;
+                }
+            }
+        }
+    }
+    const end = performance.now();
+    return end - start;
+}
+
+const t1 = runBaseline();
+const t2 = runOptimized();
+
+console.log(`Baseline: ${t1.toFixed(2)} ms`);
+console.log(`Optimized: ${t2.toFixed(2)} ms`);
+console.log(`Improvement: ${((t1 - t2) / t1 * 100).toFixed(2)}%`);

--- a/index.html
+++ b/index.html
@@ -1275,8 +1275,9 @@
                     for (let j = i + 1; j < nodes.length; j++) {
                         const dx = nodes[i].x - nodes[j].x,
                             dy = nodes[i].y - nodes[j].y;
-                        const d = Math.sqrt(dx * dx + dy * dy);
-                        if (d < 130) {
+                        const distSq = dx * dx + dy * dy;
+                        if (distSq < 16900) { // 130 * 130
+                            const d = Math.sqrt(distSq);
                             ctx.beginPath();
                             ctx.moveTo(nodes[i].x, nodes[i].y);
                             ctx.lineTo(nodes[j].x, nodes[j].y);


### PR DESCRIPTION
💡 **What:** Replaced the unconditional `Math.sqrt` computation in the nested node loops with a squared distance comparison. `Math.sqrt` is now deferred and computed only when nodes are within the `130px` threshold.

🎯 **Why:** Calculating `Math.sqrt` in every iteration of an $O(N^2)$ loop adds significant CPU overhead. By comparing squared distance instead, we eliminate thousands of costly square root calculations per frame, boosting rendering performance.

📊 **Measured Improvement:**
Measured using an isolated benchmark script mirroring the node connection loop, run across 1000 iterations for 500 nodes.
- **Baseline:** ~1005 ms
- **Optimized:** ~654 ms
- **Improvement:** ~35% speedup

---
*PR created automatically by Jules for task [5897963103932383989](https://jules.google.com/task/5897963103932383989) started by @shubhambaid*